### PR TITLE
Great Khan helmet spawn fix

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -79,7 +79,7 @@ Great Khan
 		/obj/item/gun/ballistic/revolver/caravan_shotgun, \
 		/obj/item/gun/ballistic/revolver/pipe_rifle, \
 		/obj/item/gun/ballistic/automatic/pistol/ninemil)
-	head = /obj/item/clothing/head/helmet/knight/f13/metal
+	head = /obj/item/clothing/head/helmet/f13/khan
 	shoes = /obj/item/clothing/shoes/f13/khan
 
 /datum/outfit/job/wasteland/f13pusher/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Making it so that the Great Khan role get their faction helmet instead of the metal helmet.

## Motivation and Context
Doesn't make sence for the Khans to now spawn with their helmet, but instead the kind you would see on any regular raiders.

## How Has This Been Tested?
Did it locally and it worked.


## Changelog (necessary)
:cl:
tweak: Great Khans now spawn with the correct helmet.
/:cl:
